### PR TITLE
added correct carousel logic

### DIFF
--- a/frontend/src/components/Carousel.tsx
+++ b/frontend/src/components/Carousel.tsx
@@ -6,42 +6,12 @@ const Carousel = () => {
   const featuredImages = [CarouselImgOne, CarouselImgTwo, CarouselImgOne];
 
   return (
-    <div
-      style={{
-        display: "grid",
-        overflow: "hidden",
-        position: "relative",
-        gridTemplateColumns: "50% 50%",
-        height: "319px",
-      }}
-    >
-      <h1
-        style={{
-          position: "absolute",
-          left: "50%",
-          transform: "translateX(-50%) translateY(-50%)",
-          color: "white",
-          top: "50%",
-          margin: "0",
-          textTransform: "uppercase",
-        }}
-      >
-        The Clothing Loop
-      </h1>
-      <div style={{ display: "flex" }}>
-        <img
-          src={CarouselImgOne}
-          style={{ width: "100%", height: "auto", objectFit: "cover" }}
-          alt=""
-        />
-      </div>
-      <div style={{ display: "flex" }}>
-        <img
-          src={CarouselImgTwo}
-          style={{ width: "100%", height: "auto", objectFit: "cover" }}
-          alt=""
-        />
-      </div>
+    <div id="slider" style={{}}>
+      <figure>
+        {featuredImages.map((img, i) => {
+          return <img src={img} key={i} alt="" />;
+        })}
+      </figure>
     </div>
   );
 };


### PR DESCRIPTION
After merging #157 into `main` the carousel displayed in the landing page was showing an older version. I've just updated the correct logic. 