### PR TITLE
Search bar on home page

### DIFF
--- a/frontend/src/components/FindChain/StandaloneSearchBar.tsx
+++ b/frontend/src/components/FindChain/StandaloneSearchBar.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { useHistory } from "react-router-dom";
+
+import { SearchBar } from "./SearchBar";
+
+/*
+ * A searchbar for finding loops that can be used separately from the "find
+ * loops" page. It takes the user to the "find loops" page then carries out a
+ * search with whatever values were entered
+ */
+export const StandaloneSearchBar = () => {
+  const history = useHistory();
+  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [selectedSizes, setSelectedSizes] = useState<string[]>([]);
+  const [selectedGenders, setSelectedGenders] = useState<string[]>([]);
+
+  const handleSearchTermChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handleSelectedGenderChange = (event: React.ChangeEvent<any>) => {
+    const {
+      target: { value },
+    } = event;
+
+    setSelectedGenders(typeof value === "string" ? value.split(",") : value);
+  };
+
+  const handleSearch = () => {
+    const queryParams = new URLSearchParams();
+    queryParams.append("searchTerm", searchTerm);
+    for (const size of selectedSizes) {
+      queryParams.append("sizes", size);
+    }
+    for (const gender of selectedGenders) {
+      queryParams.append("genders", gender);
+    }
+    history.push("/loops/find?" + queryParams.toString());
+  };
+
+  return (
+    <SearchBar
+      searchTerm={searchTerm}
+      handleSearchTermChange={handleSearchTermChange}
+      selectedGenders={selectedGenders}
+      handleSelectedGenderChange={handleSelectedGenderChange}
+      selectedSizes={selectedSizes}
+      setSelectedSizes={setSelectedSizes}
+      handleSearch={handleSearch}
+    />
+  );
+};

--- a/frontend/src/components/FindChain/index.tsx
+++ b/frontend/src/components/FindChain/index.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useContext, useEffect } from "react";
+import * as Yup from "yup";
 
 import { SearchBar } from "./SearchBar";
 import { ChainNotFound } from "./ChainNotFound";
 
 import { IChain } from "../../types";
+import { ChainsContext } from "../ChainsProvider";
 import { defaultTruePredicate, ChainPredicate } from "../../pages/FindChain";
 
 const hasCommonElements = (arr1: string[], arr2: string[]) =>
@@ -12,16 +14,20 @@ const hasCommonElements = (arr1: string[], arr2: string[]) =>
 interface IProps {
   setFilterChainPredicate: React.Dispatch<React.SetStateAction<ChainPredicate>>;
   handleFindChainCallback: (findChainPredicate: ChainPredicate) => boolean;
+  initialValues?: any;
 }
 
 export const FindChainSearchBarContainer = ({
   setFilterChainPredicate,
   handleFindChainCallback,
+  initialValues,
 }: IProps) => {
   const [searchTerm, setSearchTerm] = React.useState<string>("");
   const [selectedSizes, setSelectedSizes] = React.useState<string[]>([]);
   const [selectedGenders, setSelectedGenders] = React.useState<string[]>([]);
   const [isChainNotFound, setIsChainNotFound] = React.useState<boolean>(false);
+  const [formAutoFilled, setFormAutoFilled] = React.useState<boolean>(false);
+  const chains = useContext(ChainsContext);
 
   const handleSearchTermChange = (
     event: React.ChangeEvent<HTMLInputElement>
@@ -70,6 +76,34 @@ export const FindChainSearchBarContainer = ({
     setIsChainNotFound(false);
     setFilterChainPredicate(() => defaultTruePredicate);
   };
+
+  useEffect(() => {
+    // chains may not have loaded yet
+    if (!chains.length || !Object.keys(initialValues).length) {
+      return;
+    }
+    const schema = Yup.object({
+      searchTerm: Yup.string().default(""),
+      sizes: Yup.array().of(Yup.string()).default([]),
+      genders: Yup.array().of(Yup.string()).default([]),
+    });
+
+    try {
+      let validated = schema.validateSync(initialValues);
+      setSearchTerm(validated.searchTerm);
+      setSelectedSizes(validated.sizes);
+      setSelectedGenders(validated.genders);
+      setFormAutoFilled(true);
+    } catch (error) {
+      console.error("Invalid query string parameters");
+      console.error(error);
+      return;
+    }
+  }, [chains]);
+
+  useEffect(() => {
+    handleSearch();
+  }, [formAutoFilled]);
 
   return (
     <>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -40,7 +40,7 @@ const Navbar = () => {
                 {t("download")}
               </Button>
             ) : null}
-            {userData === null && location.pathname === "/loops/find" ? (
+            {userData === null && ["/loops/find", "/"].indexOf(location.pathname) !== -1 ? (
               <Button
                 color="inherit"
                 component={Link}
@@ -51,7 +51,7 @@ const Navbar = () => {
               </Button>
             ) : null}
 
-            {userData === null && location.pathname !== "/loops/find" ? (
+            {userData === null && ["/loops/find", "/"].indexOf(location.pathname) === -1 ? (
               <Button
                 color="inherit"
                 component={Link}

--- a/frontend/src/pages/FindChain.tsx
+++ b/frontend/src/pages/FindChain.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useContext, useRef } from "react";
-import { Link, useHistory, useParams } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import ReactMapGL, {
   Source,
   Layer,

--- a/frontend/src/pages/FindChain.tsx
+++ b/frontend/src/pages/FindChain.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useContext, useRef } from "react";
-import { Link, useHistory } from "react-router-dom";
+import { Link, useHistory, useParams } from "react-router-dom";
 import ReactMapGL, {
   Source,
   Layer,
@@ -84,9 +84,11 @@ const DutchLoopsCard = () => {
       </CardContent>
     </Card>
   );
-}
+};
 
-const FindChain = () => {
+const FindChain = ({ location }: { location: Location }) => {
+  const urlParams = new URLSearchParams(location.search);
+
   const history = useHistory();
   const { t } = useTranslation();
   const { user } = useContext(AuthContext);
@@ -149,21 +151,19 @@ const FindChain = () => {
   }, []);
 
   useEffect(() => {
-    navigator.geolocation.getCurrentPosition(
-      (location) => {
-        const { longitude, latitude } = location.coords;
-        fetch(
-          `https://api.mapbox.com/geocoding/v5/mapbox.places/${longitude},${latitude}.json?access_token=${accessToken.mapboxApiAccessToken}&types=country`
-        ).then(
-          (response) => response.json()
-        ).then((data) => {
+    navigator.geolocation.getCurrentPosition((location) => {
+      const { longitude, latitude } = location.coords;
+      fetch(
+        `https://api.mapbox.com/geocoding/v5/mapbox.places/${longitude},${latitude}.json?access_token=${accessToken.mapboxApiAccessToken}&types=country`
+      )
+        .then((response) => response.json())
+        .then((data) => {
           if (data.features[0].properties.short_code === "nl") {
             setShowDutchLoopsDialog(true);
           }
         });
-      }
-    );
-  }, [])
+    });
+  }, []);
 
   if (!accessToken.mapboxApiAccessToken) {
     return <div>Access tokens not configured</div>;
@@ -295,12 +295,17 @@ const FindChain = () => {
       <FindChainSearchBarContainer
         setFilterChainPredicate={setFilterChainPredicate}
         handleFindChainCallback={handleFindChainCallback}
+        initialValues={{
+          searchTerm: urlParams.get("searchTerm") || "",
+          sizes: urlParams.getAll("sizes") || [],
+          genders: urlParams.getAll("genders") || [],
+        }}
       />
 
       <Dialog
         open={showDutchLoopsDialog}
         onClose={() => setShowDutchLoopsDialog(false)}
-      > 
+      >
         <DutchLoopsCard />
       </Dialog>
 
@@ -368,7 +373,7 @@ const FindChain = () => {
             paint={{ "text-color": "white" }}
           />
         </Source>
-  
+
         {/* ====start TO REMOVE ONCE ALL DUTCH LOOPS ARE MIGRATED INTO FIREBASE */}
         <Marker
           key={"marker-netherlands"}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -34,6 +34,7 @@ import EssenseLogo from "../images/logos/essense-logo.svg";
 import WdcdLogo from "../images/logos/Logo_WDCD.png";
 import DoenLogo from "../images/logos/DOEN.png";
 import PNHLogo from "../images/logos/PNH_logo.png";
+import { StandaloneSearchBar } from "../components/FindChain/StandaloneSearchBar";
 
 const Home = () => {
   const chainsCount = React.useContext(ChainsContext).length;
@@ -92,6 +93,8 @@ const Home = () => {
         <title>The Clothing Loop | Home</title>
         <meta name="description" content="Home" />
       </Helmet>
+
+      <StandaloneSearchBar />
 
       <div id="landing-page-desktop" className={classes.landingPageDesktop}>
         <div className={classes.landingPageWrapper}>


### PR DESCRIPTION
Adds the search bar used in "find loops" page to the home page, as per #187.

Clicking search takes the user to the "find loops" page with the values from the form sent in the URL query string. The "find loops" page then pre-fills its form with these values and carries out a search (once the list of existing loops has been loaded). 