### PR TITLE
Refactor Dropdown

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -366,15 +366,6 @@
     text-transform: "capitalize";
   }
 
-  div#demo-multiple-checkbox {
-    padding: 10px !important;
-    padding-left: 0 !important;
-    font-family: "Montserrat" !important;
-    text-align: left;
-    text-transform: capitalize;
-    color: #3c3c3b;
-  }
-
   fieldset.MuiOutlinedInput-notchedOutline {
     border-color: transparent;
   }
@@ -858,4 +849,8 @@
     width: 100%;
     border-bottom: 1px solid rgb(72, 128, 139);
   }
+}
+
+.search-bar__dropdown {
+  width: 15rem;
 }

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -9,6 +9,7 @@ import {
   FormControl,
   MenuItem,
   Typography,
+  SelectChangeEvent,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
@@ -19,8 +20,8 @@ interface IProps {
   variant: "outlined" | "standard";
   showInputLabel: boolean;
   renderValueWhenEmpty?: string;
-  setGenders: (el: string[]) => void;
-  genders: string[];
+  selectedCategories: string[];
+  handleSelectedCategoriesChange: (selectedCategories: string[]) => void;
   className: string;
   fullWidth: boolean;
 }
@@ -29,25 +30,24 @@ const CategoriesDropdown: React.FC<IProps> = ({
   variant,
   showInputLabel,
   renderValueWhenEmpty,
-  genders,
-  setGenders,
+  selectedCategories,
+  handleSelectedCategoriesChange,
   className,
   fullWidth,
 }: IProps) => {
   const classes = makeStyles(theme as any)();
   const { t } = useTranslation();
 
-  const selectedGenders = genders;
-  const setSelectedGenders = setGenders;
   const stylingClass = className;
 
-  //get selected categories
-  const handleChange = (event: any, setCategories: any) => {
+  const handleOnChange = (event: SelectChangeEvent<string[]>) => {
     const {
       target: { value },
     } = event;
 
-    setCategories(typeof value === "string" ? value.split(",") : value);
+    handleSelectedCategoriesChange(
+      typeof value === "string" ? value.split(",") : value
+    );
   };
 
   return (
@@ -64,8 +64,8 @@ const CategoriesDropdown: React.FC<IProps> = ({
         multiple
         displayEmpty
         variant={variant}
-        value={selectedGenders}
-        onChange={(e: any) => handleChange(e, setSelectedGenders)}
+        value={selectedCategories}
+        onChange={handleOnChange}
         renderValue={(selected: string[]) =>
           !selected.length && renderValueWhenEmpty ? (
             <Typography
@@ -90,7 +90,7 @@ const CategoriesDropdown: React.FC<IProps> = ({
           >
             <Checkbox
               color="secondary"
-              checked={selectedGenders.includes(value) ? true : false}
+              checked={selectedCategories.includes(value) ? true : false}
             />
             <ListItemText
               primary={t(value)}

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -23,7 +23,6 @@ interface IProps {
   selectedCategories: string[];
   handleSelectedCategoriesChange: (selectedCategories: string[]) => void;
   className: string;
-  fullWidth: boolean;
 }
 
 const CategoriesDropdown: React.FC<IProps> = ({
@@ -33,7 +32,6 @@ const CategoriesDropdown: React.FC<IProps> = ({
   selectedCategories,
   handleSelectedCategoriesChange,
   className,
-  fullWidth,
 }: IProps) => {
   const classes = makeStyles(theme as any)();
   const { t } = useTranslation();

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -59,11 +59,19 @@ const CategoriesDropdown: React.FC<IProps> = ({
         multiple
         displayEmpty
         input={
-          <Input
-            classes={{
-              root: classes.formSelect,
-            }}
-          />
+          variant === "outlined" ? (
+            <OutlinedInput
+              classes={{
+                root: classes.select,
+              }}
+            />
+          ) : (
+            <Input
+              classes={{
+                root: classes.formSelect,
+              }}
+            />
+          )
         }
         variant={variant}
         value={selectedCategories}

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -2,14 +2,14 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 
 import {
+  FormControl,
   InputLabel,
-  Checkbox,
-  ListItemText,
   Select,
   Input,
   OutlinedInput,
-  FormControl,
   MenuItem,
+  Checkbox,
+  ListItemText,
   Typography,
   SelectChangeEvent,
 } from "@mui/material";

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -79,7 +79,7 @@ const CategoriesDropdown: React.FC<IProps> = ({
             }}
           >
             <Checkbox
-              className={classes.checkbox}
+              color="secondary"
               checked={selectedGenders.includes(value) ? true : false}
             />
             <ListItemText

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -84,8 +84,6 @@ const CategoriesDropdown: React.FC<IProps> = ({
             />
             <ListItemText
               primary={t(value)}
-              className={classes.listItemTextSizes}
-              style={{ textTransform: "capitalize" }}
               classes={{
                 primary: classes.listItemTextFontSize,
               }}

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -6,6 +6,8 @@ import {
   Checkbox,
   ListItemText,
   Select,
+  Input,
+  OutlinedInput,
   FormControl,
   MenuItem,
   Typography,
@@ -22,7 +24,6 @@ interface IProps {
   renderValueWhenEmpty?: string;
   selectedCategories: string[];
   handleSelectedCategoriesChange: (selectedCategories: string[]) => void;
-  className: string;
 }
 
 const CategoriesDropdown: React.FC<IProps> = ({
@@ -31,12 +32,9 @@ const CategoriesDropdown: React.FC<IProps> = ({
   renderValueWhenEmpty,
   selectedCategories,
   handleSelectedCategoriesChange,
-  className,
 }: IProps) => {
   const classes = makeStyles(theme as any)();
   const { t } = useTranslation();
-
-  const stylingClass = className;
 
   const handleOnChange = (event: SelectChangeEvent<string[]>) => {
     const {
@@ -56,11 +54,17 @@ const CategoriesDropdown: React.FC<IProps> = ({
         </InputLabel>
       )}
       <Select
-        className={stylingClass}
         labelId="demo-multiple-checkbox-label"
         id="demo-multiple-checkbox"
         multiple
         displayEmpty
+        input={
+          <Input
+            classes={{
+              root: classes.formSelect,
+            }}
+          />
+        }
         variant={variant}
         value={selectedCategories}
         onChange={handleOnChange}

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -44,11 +44,7 @@ const CategoriesDropdown: React.FC<IProps> = ({
   };
 
   return (
-    <FormControl
-      className={classes.sizesFormWrapper}
-      fullWidth={fullWidth}
-      classes={{ root: classes.specificSpacing }}
-    >
+    <FormControl classes={{ root: classes.specificSpacing }} fullWidth>
       <InputLabel
         id="demo-multiple-checkbox-label"
         className={classes.labelSelect}

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -50,11 +50,7 @@ const CategoriesDropdown: React.FC<IProps> = ({
 
   return (
     <FormControl classes={{ root: classes.specificSpacing }} fullWidth>
-      <InputLabel
-        id="demo-multiple-checkbox-label"
-        className={classes.labelSelect}
-        classes={{ root: classes.focusColor }}
-      >
+      <InputLabel classes={{ root: classes.labelSelect }}>
         {t("categories")}
       </InputLabel>
       <Select

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -17,6 +17,7 @@ import categories from "../util/categories";
 
 interface IProps {
   variant: "outlined" | "standard";
+  showInputLabel: boolean;
   renderValueWhenEmpty?: string;
   setGenders: (el: string[]) => void;
   genders: string[];
@@ -26,6 +27,7 @@ interface IProps {
 
 const CategoriesDropdown: React.FC<IProps> = ({
   variant,
+  showInputLabel,
   renderValueWhenEmpty,
   genders,
   setGenders,
@@ -50,9 +52,11 @@ const CategoriesDropdown: React.FC<IProps> = ({
 
   return (
     <FormControl classes={{ root: classes.specificSpacing }} fullWidth>
-      <InputLabel classes={{ root: classes.labelSelect }}>
-        {t("categories")}
-      </InputLabel>
+      {showInputLabel && (
+        <InputLabel classes={{ root: classes.labelSelect }}>
+          {t("categories")}
+        </InputLabel>
+      )}
       <Select
         className={stylingClass}
         labelId="demo-multiple-checkbox-label"

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -16,6 +16,7 @@ import theme from "../util/theme";
 import categories from "../util/categories";
 
 interface IProps {
+  variant: "outlined" | "standard";
   renderValueWhenEmpty?: string;
   setGenders: (el: string[]) => void;
   genders: string[];
@@ -24,6 +25,7 @@ interface IProps {
 }
 
 const CategoriesDropdown: React.FC<IProps> = ({
+  variant,
   renderValueWhenEmpty,
   genders,
   setGenders,
@@ -61,7 +63,7 @@ const CategoriesDropdown: React.FC<IProps> = ({
         id="demo-multiple-checkbox"
         multiple
         displayEmpty
-        variant="standard"
+        variant={variant}
         value={selectedGenders}
         onChange={(e: any) => handleChange(e, setSelectedGenders)}
         renderValue={(selected: string[]) =>

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -8,6 +8,7 @@ import {
   Select,
   FormControl,
   MenuItem,
+  Typography,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
@@ -15,6 +16,7 @@ import theme from "../util/theme";
 import categories from "../util/categories";
 
 interface IProps {
+  renderValueWhenEmpty?: string;
   setGenders: (el: string[]) => void;
   genders: string[];
   className: string;
@@ -22,6 +24,7 @@ interface IProps {
 }
 
 const CategoriesDropdown: React.FC<IProps> = ({
+  renderValueWhenEmpty,
   genders,
   setGenders,
   className,
@@ -61,9 +64,18 @@ const CategoriesDropdown: React.FC<IProps> = ({
         variant="standard"
         value={selectedGenders}
         onChange={(e: any) => handleChange(e, setSelectedGenders)}
-        renderValue={(selected: string[]) => {
-          return selected.map(t).join(", ");
-        }}
+        renderValue={(selected: string[]) =>
+          !selected.length && renderValueWhenEmpty ? (
+            <Typography
+              component="span"
+              classes={{ root: classes.emptyRenderValue }}
+            >
+              {renderValueWhenEmpty}
+            </Typography>
+          ) : (
+            selected.map(t).join(", ")
+          )
+        }
       >
         {Object.keys(categories).map((value: string) => (
           <MenuItem

--- a/frontend/src/components/CategoriesDropdown.tsx
+++ b/frontend/src/components/CategoriesDropdown.tsx
@@ -54,25 +54,29 @@ const CategoriesDropdown: React.FC<IProps> = ({
         </InputLabel>
       )}
       <Select
-        labelId="demo-multiple-checkbox-label"
-        id="demo-multiple-checkbox"
         multiple
         displayEmpty
         input={
           variant === "outlined" ? (
             <OutlinedInput
               classes={{
-                root: classes.select,
+                root: classes.selectInputOutlined,
               }}
             />
           ) : (
             <Input
               classes={{
-                root: classes.formSelect,
+                root: classes.selectInputStandard,
               }}
             />
           )
         }
+        classes={{
+          select:
+            variant === "outlined"
+              ? classes.selectOutlined
+              : classes.selectStandard,
+        }}
         variant={variant}
         value={selectedCategories}
         onChange={handleOnChange}

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -288,7 +288,6 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                         selectedCategories={values.clothingTypes}
                         handleSelectedCategoriesChange={handleCategoriesChange}
                         className={classes.formSelect}
-                        fullWidth={true}
                       />
                     </div>
                     <div style={{ paddingTop: "10px", position: "relative" }}>
@@ -297,7 +296,6 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                         showInputLabel={true}
                         className={classes.formSelect}
                         label={t("sizes")}
-                        fullWidth={false}
                         selectedGenders={values.clothingTypes}
                         selectedSizes={values.clothingSizes}
                         handleSelectedCategoriesChange={(val) =>

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -294,13 +294,13 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                     <div style={{ paddingTop: "10px", position: "relative" }}>
                       <SizesDropdown
                         variant="standard"
+                        showInputLabel={true}
                         setSizes={(val) => setFieldValue("clothingSizes", val)}
                         className={classes.formSelect}
                         genders={values.clothingTypes}
                         sizes={values.clothingSizes}
                         label={t("sizes")}
                         fullWidth={false}
-                        inputVisible={true}
                       />
                       <PopoverOnHover
                         message={

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -294,7 +294,6 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                       <SizesDropdown
                         variant="standard"
                         showInputLabel={true}
-                        className={classes.formSelect}
                         label={t("sizes")}
                         selectedGenders={values.clothingTypes}
                         selectedSizes={values.clothingSizes}

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -293,6 +293,7 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                     </div>
                     <div style={{ paddingTop: "10px", position: "relative" }}>
                       <SizesDropdown
+                        variant="standard"
                         setSizes={(val) => setFieldValue("clothingSizes", val)}
                         className={classes.formSelect}
                         genders={values.clothingTypes}
@@ -300,7 +301,6 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                         label={t("sizes")}
                         fullWidth={false}
                         inputVisible={true}
-                        variantVal={true}
                       />
                       <PopoverOnHover
                         message={

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -284,6 +284,7 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                     <div style={{ paddingTop: "10px" }}>
                       <CategoriesDropdown
                         variant="standard"
+                        showInputLabel={true}
                         setGenders={handleCategoriesChange}
                         genders={values.clothingTypes}
                         className={classes.formSelect}

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -295,12 +295,14 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                       <SizesDropdown
                         variant="standard"
                         showInputLabel={true}
-                        setSizes={(val) => setFieldValue("clothingSizes", val)}
                         className={classes.formSelect}
-                        genders={values.clothingTypes}
-                        sizes={values.clothingSizes}
                         label={t("sizes")}
                         fullWidth={false}
+                        selectedGenders={values.clothingTypes}
+                        selectedSizes={values.clothingSizes}
+                        handleSelectedCategoriesChange={(val) =>
+                          setFieldValue("clothingSizes", val)
+                        }
                       />
                       <PopoverOnHover
                         message={

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -241,7 +241,7 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                       }
                     />
                   </Grid>
-                  <Grid item xs={3} style={{paddingTop:'10px'}}>
+                  <Grid item xs={3} style={{ paddingTop: "10px" }}>
                     <NumberField
                       required
                       label={t("radius")}

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -285,8 +285,8 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                       <CategoriesDropdown
                         variant="standard"
                         showInputLabel={true}
-                        setGenders={handleCategoriesChange}
-                        genders={values.clothingTypes}
+                        selectedCategories={values.clothingTypes}
+                        handleSelectedCategoriesChange={handleCategoriesChange}
                         className={classes.formSelect}
                         fullWidth={true}
                       />

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -283,6 +283,7 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                   <Grid item xs={12} style={{ position: "relative" }}>
                     <div style={{ paddingTop: "10px" }}>
                       <CategoriesDropdown
+                        variant="standard"
                         setGenders={handleCategoriesChange}
                         genders={values.clothingTypes}
                         className={classes.formSelect}

--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -287,7 +287,6 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
                         showInputLabel={true}
                         selectedCategories={values.clothingTypes}
                         handleSelectedCategoriesChange={handleCategoriesChange}
-                        className={classes.formSelect}
                       />
                     </div>
                     <div style={{ paddingTop: "10px", position: "relative" }}>

--- a/frontend/src/components/FindChain/SearchBar.tsx
+++ b/frontend/src/components/FindChain/SearchBar.tsx
@@ -115,13 +115,13 @@ export const SearchBar: React.FC<IProps> = ({
       <div className={classes.formControl}>
         <SizesDropdown
           variant="outlined"
+          showInputLabel={false}
           className={classes.select}
           genders={selectedGenders}
           sizes={selectedSizes}
           setSizes={setSelectedSizes}
           label={t("sizes")}
           fullWidth={false}
-          inputVisible={false}
         />
       </div>
 

--- a/frontend/src/components/FindChain/SearchBar.tsx
+++ b/frontend/src/components/FindChain/SearchBar.tsx
@@ -114,6 +114,7 @@ export const SearchBar: React.FC<IProps> = ({
 
       <div className={classes.formControl}>
         <SizesDropdown
+          variant="outlined"
           className={classes.select}
           genders={selectedGenders}
           sizes={selectedSizes}
@@ -121,7 +122,6 @@ export const SearchBar: React.FC<IProps> = ({
           label={t("sizes")}
           fullWidth={false}
           inputVisible={false}
-          variantVal={false}
         />
       </div>
 

--- a/frontend/src/components/FindChain/SearchBar.tsx
+++ b/frontend/src/components/FindChain/SearchBar.tsx
@@ -116,7 +116,6 @@ export const SearchBar: React.FC<IProps> = ({
         <SizesDropdown
           variant="outlined"
           showInputLabel={false}
-          className={classes.select}
           label={t("sizes")}
           selectedGenders={selectedGenders}
           selectedSizes={selectedSizes}

--- a/frontend/src/components/FindChain/SearchBar.tsx
+++ b/frontend/src/components/FindChain/SearchBar.tsx
@@ -117,11 +117,11 @@ export const SearchBar: React.FC<IProps> = ({
           variant="outlined"
           showInputLabel={false}
           className={classes.select}
-          genders={selectedGenders}
-          sizes={selectedSizes}
-          setSizes={setSelectedSizes}
           label={t("sizes")}
           fullWidth={false}
+          selectedGenders={selectedGenders}
+          selectedSizes={selectedSizes}
+          handleSelectedCategoriesChange={setSelectedSizes}
         />
       </div>
 

--- a/frontend/src/components/FindChain/SearchBar.tsx
+++ b/frontend/src/components/FindChain/SearchBar.tsx
@@ -118,7 +118,6 @@ export const SearchBar: React.FC<IProps> = ({
           showInputLabel={false}
           className={classes.select}
           label={t("sizes")}
-          fullWidth={false}
           selectedGenders={selectedGenders}
           selectedSizes={selectedSizes}
           handleSelectedCategoriesChange={setSelectedSizes}

--- a/frontend/src/components/FindChain/SearchBar.tsx
+++ b/frontend/src/components/FindChain/SearchBar.tsx
@@ -54,7 +54,7 @@ export const SearchBar: React.FC<IProps> = ({
         }}
       />
 
-      <div className={classes.formControl}>
+      <div className="search-bar__dropdown">
         <CategoriesDropdown
           variant="outlined"
           showInputLabel={false}
@@ -64,7 +64,7 @@ export const SearchBar: React.FC<IProps> = ({
         />
       </div>
 
-      <div className={classes.formControl}>
+      <div className="search-bar__dropdown">
         <SizesDropdown
           variant="outlined"
           showInputLabel={false}

--- a/frontend/src/components/FindChain/SearchBar.tsx
+++ b/frontend/src/components/FindChain/SearchBar.tsx
@@ -1,24 +1,14 @@
 import { useTranslation } from "react-i18next";
 
-import {
-  MenuItem,
-  FormControl,
-  Select,
-  ListItemText,
-  Checkbox,
-  TextField,
-  InputAdornment,
-  Button,
-  Paper,
-} from "@mui/material";
+import { TextField, InputAdornment, Button, Paper } from "@mui/material";
 import { Search } from "@mui/icons-material";
 import { makeStyles } from "@mui/styles";
 
+import CategoriesDropdown from "../CategoriesDropdown";
 import SizesDropdown from "../SizesDropdown";
 
 // Project resources
 import theme from "../../util/theme";
-import categories from "../../util/categories";
 
 interface IProps {
   searchTerm: string;
@@ -64,53 +54,15 @@ export const SearchBar: React.FC<IProps> = ({
         }}
       />
 
-      <FormControl className={classes.formControl}>
-        <Select
-          displayEmpty
-          className={classes.select}
-          labelId="demo-multiple-checkbox-label"
-          id="demo-multiple-checkbox"
-          multiple
+      <div className={classes.formControl}>
+        <CategoriesDropdown
           variant="outlined"
-          value={selectedGenders}
-          onChange={handleSelectedGenderChange}
-          inputProps={{
-            className: classes.specificSpacing,
-          }}
-          renderValue={(selected) => {
-            if (Array.isArray(selected)) {
-              if (selected.length === 0) {
-                return <em className={classes.em}>{t("categories")}</em>;
-              }
-
-              return selected.map(t).join(", ");
-            }
-          }}
-        >
-          {Object.keys(categories).map((value: any) => (
-            <MenuItem
-              key={value}
-              value={value}
-              classes={{
-                root: classes.menuItemSpacingAndColor,
-                selected: classes.selected,
-              }}
-            >
-              <Checkbox
-                className={classes.checkbox}
-                checked={selectedGenders.includes(value) ? true : false}
-              />
-              <ListItemText
-                primary={t(value)}
-                className={classes.listItemText}
-                classes={{
-                  primary: classes.listItemTextFontSize,
-                }}
-              />
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+          showInputLabel={false}
+          renderValueWhenEmpty={t("categories")}
+          selectedCategories={selectedGenders}
+          handleSelectedCategoriesChange={handleSelectedGenderChange}
+        />
+      </div>
 
       <div className={classes.formControl}>
         <SizesDropdown

--- a/frontend/src/components/FindChain/StandaloneSearchBar.tsx
+++ b/frontend/src/components/FindChain/StandaloneSearchBar.tsx
@@ -20,14 +20,6 @@ export const StandaloneSearchBar = () => {
     setSearchTerm(event.target.value);
   };
 
-  const handleSelectedGenderChange = (event: React.ChangeEvent<any>) => {
-    const {
-      target: { value },
-    } = event;
-
-    setSelectedGenders(typeof value === "string" ? value.split(",") : value);
-  };
-
   const handleSearch = () => {
     const queryParams = new URLSearchParams();
     queryParams.append("searchTerm", searchTerm);
@@ -45,7 +37,7 @@ export const StandaloneSearchBar = () => {
       searchTerm={searchTerm}
       handleSearchTermChange={handleSearchTermChange}
       selectedGenders={selectedGenders}
-      handleSelectedGenderChange={handleSelectedGenderChange}
+      handleSelectedGenderChange={setSelectedGenders}
       selectedSizes={selectedSizes}
       setSelectedSizes={setSelectedSizes}
       handleSearch={handleSearch}

--- a/frontend/src/components/FormFields.js
+++ b/frontend/src/components/FormFields.js
@@ -121,7 +121,7 @@ const CheckboxField = ({ required, label, ...props }) => {
           <Checkbox
             required={required ? true : false}
             name={field.name}
-            className={classes.checkbox}
+            color="secondary"
           />
         }
         {...field}

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -112,6 +112,7 @@ const SizesDropdown: React.FC<IProps> = ({
             />
           </MenuItem>
         ))}
+
         <Typography component="p" className={classes.label}>
           {t("womenSizes")}
         </Typography>
@@ -139,6 +140,7 @@ const SizesDropdown: React.FC<IProps> = ({
             />
           </MenuItem>
         ))}
+
         <Typography component="p" className={classes.label}>
           {t("menSizes")}
         </Typography>
@@ -170,4 +172,5 @@ const SizesDropdown: React.FC<IProps> = ({
     </FormControl>
   );
 };
+
 export default SizesDropdown;

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -87,7 +87,7 @@ const SizesDropdown: React.FC<IProps> = ({
       >
         <Typography component="p" className={classes.label}>
           {t("childrenSizes")}
-        </Typography>{" "}
+        </Typography>
         {categories.children.map((value: any) => (
           <MenuItem
             key={value}
@@ -114,7 +114,7 @@ const SizesDropdown: React.FC<IProps> = ({
         ))}
         <Typography component="p" className={classes.label}>
           {t("womenSizes")}
-        </Typography>{" "}
+        </Typography>
         {categories.women.map((value: any) => (
           <MenuItem
             disabled={
@@ -141,7 +141,7 @@ const SizesDropdown: React.FC<IProps> = ({
         ))}
         <Typography component="p" className={classes.label}>
           {t("menSizes")}
-        </Typography>{" "}
+        </Typography>
         {categories.men.map((value: any) => (
           <MenuItem
             disabled={

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -91,6 +91,7 @@ const SizesDropdown: React.FC<IProps> = ({
         {categories.children.map((value: string) => (
           <MenuItem
             key={value}
+            value={value}
             disabled={
               !selectedGenders.includes("children") && !!selectedGenders.length
             }
@@ -98,7 +99,6 @@ const SizesDropdown: React.FC<IProps> = ({
               root: classes.menuItemSpacingAndColor,
               selected: classes.selected,
             }}
-            value={value}
           >
             <Checkbox
               color="secondary"
@@ -118,6 +118,8 @@ const SizesDropdown: React.FC<IProps> = ({
         </Typography>
         {categories.women.map((value: string) => (
           <MenuItem
+            key={value}
+            value={value}
             disabled={
               !selectedGenders.includes("women") && !!selectedGenders.length
             }
@@ -125,8 +127,6 @@ const SizesDropdown: React.FC<IProps> = ({
               root: classes.menuItemSpacingAndColor,
               selected: classes.selected,
             }}
-            key={value}
-            value={value}
           >
             <Checkbox
               color="secondary"
@@ -146,6 +146,8 @@ const SizesDropdown: React.FC<IProps> = ({
         </Typography>
         {categories.men.map((value: string) => (
           <MenuItem
+            key={value}
+            value={value}
             disabled={
               !selectedGenders.includes("men") && !!selectedGenders.length
             }
@@ -153,8 +155,6 @@ const SizesDropdown: React.FC<IProps> = ({
               root: classes.menuItemSpacingAndColor,
               selected: classes.selected,
             }}
-            key={value}
-            value={value}
           >
             <Checkbox
               color="secondary"

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -16,6 +16,7 @@ import theme from "../util/theme";
 import categories from "../util/categories";
 
 interface IProps {
+  variant: "outlined" | "standard";
   setSizes: (el: string[]) => void;
   genders: string[];
   sizes: string[];
@@ -23,10 +24,10 @@ interface IProps {
   label: string;
   fullWidth: boolean;
   inputVisible: boolean;
-  variantVal: boolean;
 }
 
 const SizesDropdown: React.FC<IProps> = ({
+  variant,
   genders,
   setSizes,
   sizes,
@@ -34,7 +35,6 @@ const SizesDropdown: React.FC<IProps> = ({
   label,
   fullWidth,
   inputVisible,
-  variantVal,
 }: IProps) => {
   const classes = makeStyles(theme as any)();
   const { t } = useTranslation();
@@ -67,7 +67,7 @@ const SizesDropdown: React.FC<IProps> = ({
         id="demo-multiple-checkbox"
         multiple
         displayEmpty
-        variant={variantVal ? "standard" : "outlined"}
+        variant={variant}
         value={selectedSizes}
         onChange={(e: any) => handleChange(e, setSelectedSizes)}
         renderValue={(selected: string[]) => {

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -54,11 +54,7 @@ const SizesDropdown: React.FC<IProps> = ({
   };
 
   return (
-    <FormControl
-      className={classes.sizesFormWrapper}
-      fullWidth={fullWidth}
-      classes={{ root: classes.specificSpacing }}
-    >
+    <FormControl classes={{ root: classes.specificSpacing }} fullWidth>
       {inputVisible ? (
         <InputLabel
           id="demo-multiple-checkbox-label"

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -5,6 +5,8 @@ import {
   MenuItem,
   FormControl,
   Select,
+  Input,
+  OutlinedInput,
   ListItemText,
   Checkbox,
   Typography,
@@ -19,7 +21,6 @@ import categories from "../util/categories";
 interface IProps {
   variant: "outlined" | "standard";
   showInputLabel: boolean;
-  className: string;
   label: string;
   selectedGenders: string[];
   selectedSizes: string[];
@@ -29,7 +30,6 @@ interface IProps {
 const SizesDropdown: React.FC<IProps> = ({
   variant,
   showInputLabel,
-  className,
   label,
   selectedGenders,
   selectedSizes,
@@ -37,8 +37,6 @@ const SizesDropdown: React.FC<IProps> = ({
 }: IProps) => {
   const classes = makeStyles(theme as any)();
   const { t } = useTranslation();
-
-  const stylingClass = className;
 
   const handleOnChange = (event: SelectChangeEvent<string[]>) => {
     const {
@@ -56,14 +54,25 @@ const SizesDropdown: React.FC<IProps> = ({
         <InputLabel classes={{ root: classes.labelSelect }}>{label}</InputLabel>
       )}
       <Select
-        className={stylingClass}
-        inputProps={{
-          className: classes.inputLabel,
-        }}
         labelId="demo-multiple-checkbox-label"
         id="demo-multiple-checkbox"
         multiple
         displayEmpty
+        input={
+          variant === "outlined" ? (
+            <OutlinedInput
+              classes={{
+                root: classes.select,
+              }}
+            />
+          ) : (
+            <Input
+              classes={{
+                root: classes.formSelect,
+              }}
+            />
+          )
+        }
         variant={variant}
         value={selectedSizes}
         onChange={handleOnChange}

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -21,7 +21,6 @@ interface IProps {
   showInputLabel: boolean;
   className: string;
   label: string;
-  fullWidth: boolean;
   selectedGenders: string[];
   selectedSizes: string[];
   handleSelectedCategoriesChange: (selectedCategories: string[]) => void;
@@ -32,7 +31,6 @@ const SizesDropdown: React.FC<IProps> = ({
   showInputLabel,
   className,
   label,
-  fullWidth,
   selectedGenders,
   selectedSizes,
   handleSelectedCategoriesChange,

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -92,8 +92,7 @@ const SizesDropdown: React.FC<IProps> = ({
           <MenuItem
             key={value}
             disabled={
-              !selectedGenders.includes("children") &&
-              selectedGenders.length !== 0
+              !selectedGenders.includes("children") && !!selectedGenders.length
             }
             classes={{
               root: classes.menuItemSpacingAndColor,
@@ -119,7 +118,7 @@ const SizesDropdown: React.FC<IProps> = ({
         {categories.women.map((value: any) => (
           <MenuItem
             disabled={
-              !selectedGenders.includes("women") && selectedGenders.length !== 0
+              !selectedGenders.includes("women") && !!selectedGenders.length
             }
             classes={{
               root: classes.menuItemSpacingAndColor,
@@ -146,7 +145,7 @@ const SizesDropdown: React.FC<IProps> = ({
         {categories.men.map((value: any) => (
           <MenuItem
             disabled={
-              !selectedGenders.includes("men") && selectedGenders.length !== 0
+              !selectedGenders.includes("men") && !!selectedGenders.length
             }
             classes={{
               root: classes.menuItemSpacingAndColor,

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -109,7 +109,7 @@ const SizesDropdown: React.FC<IProps> = ({
             value={value}
           >
             <Checkbox
-              className={classes.checkbox}
+              color="secondary"
               checked={selectedSizes.includes(value) ? true : false}
             />
             <ListItemText
@@ -138,7 +138,7 @@ const SizesDropdown: React.FC<IProps> = ({
             value={value}
           >
             <Checkbox
-              className={classes.checkbox}
+              color="secondary"
               checked={selectedSizes.includes(value) ? true : false}
             />
             <ListItemText
@@ -167,7 +167,7 @@ const SizesDropdown: React.FC<IProps> = ({
             value={value}
           >
             <Checkbox
-              className={classes.checkbox}
+              color="secondary"
               checked={selectedSizes.includes(value) ? true : false}
             />
             <ListItemText

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -114,11 +114,9 @@ const SizesDropdown: React.FC<IProps> = ({
             />
             <ListItemText
               primary={t(value)}
-              className={classes.listItemTextSizes}
               classes={{
                 primary: classes.listItemTextFontSize,
               }}
-              style={{ textTransform: "capitalize" }}
             />
           </MenuItem>
         ))}
@@ -143,11 +141,9 @@ const SizesDropdown: React.FC<IProps> = ({
             />
             <ListItemText
               primary={t(value)}
-              className={classes.listItemTextSizes}
               classes={{
                 primary: classes.listItemTextFontSize,
               }}
-              style={{ textTransform: "capitalize" }}
             />
           </MenuItem>
         ))}
@@ -172,11 +168,9 @@ const SizesDropdown: React.FC<IProps> = ({
             />
             <ListItemText
               primary={t(value)}
-              className={classes.listItemTextSizes}
               classes={{
                 primary: classes.listItemTextFontSize,
               }}
-              style={{ textTransform: "capitalize" }}
             />
           </MenuItem>
         ))}

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -17,24 +17,24 @@ import categories from "../util/categories";
 
 interface IProps {
   variant: "outlined" | "standard";
+  showInputLabel: boolean;
   setSizes: (el: string[]) => void;
   genders: string[];
   sizes: string[];
   className: string;
   label: string;
   fullWidth: boolean;
-  inputVisible: boolean;
 }
 
 const SizesDropdown: React.FC<IProps> = ({
   variant,
+  showInputLabel,
   genders,
   setSizes,
   sizes,
   className,
   label,
   fullWidth,
-  inputVisible,
 }: IProps) => {
   const classes = makeStyles(theme as any)();
   const { t } = useTranslation();
@@ -55,9 +55,9 @@ const SizesDropdown: React.FC<IProps> = ({
 
   return (
     <FormControl classes={{ root: classes.specificSpacing }} fullWidth>
-      {inputVisible ? (
+      {showInputLabel && (
         <InputLabel classes={{ root: classes.labelSelect }}>{label}</InputLabel>
-      ) : null}
+      )}
       <Select
         className={stylingClass}
         inputProps={{
@@ -72,7 +72,7 @@ const SizesDropdown: React.FC<IProps> = ({
         onChange={(e: any) => handleChange(e, setSelectedSizes)}
         renderValue={(selected: string[]) => {
           if (!selected.length) {
-            return inputVisible ? null : (
+            return showInputLabel ? null : (
               <Typography
                 component="span"
                 classes={{ root: classes.emptyRenderValue }}

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -54,25 +54,29 @@ const SizesDropdown: React.FC<IProps> = ({
         <InputLabel classes={{ root: classes.labelSelect }}>{label}</InputLabel>
       )}
       <Select
-        labelId="demo-multiple-checkbox-label"
-        id="demo-multiple-checkbox"
         multiple
         displayEmpty
         input={
           variant === "outlined" ? (
             <OutlinedInput
               classes={{
-                root: classes.select,
+                root: classes.selectInputOutlined,
               }}
             />
           ) : (
             <Input
               classes={{
-                root: classes.formSelect,
+                root: classes.selectInputStandard,
               }}
             />
           )
         }
+        classes={{
+          select:
+            variant === "outlined"
+              ? classes.selectOutlined
+              : classes.selectStandard,
+        }}
         variant={variant}
         value={selectedSizes}
         onChange={handleOnChange}

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -9,6 +9,7 @@ import {
   Checkbox,
   Typography,
   InputLabel,
+  SelectChangeEvent,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
@@ -18,39 +19,37 @@ import categories from "../util/categories";
 interface IProps {
   variant: "outlined" | "standard";
   showInputLabel: boolean;
-  setSizes: (el: string[]) => void;
-  genders: string[];
-  sizes: string[];
   className: string;
   label: string;
   fullWidth: boolean;
+  selectedGenders: string[];
+  selectedSizes: string[];
+  handleSelectedCategoriesChange: (selectedCategories: string[]) => void;
 }
 
 const SizesDropdown: React.FC<IProps> = ({
   variant,
   showInputLabel,
-  genders,
-  setSizes,
-  sizes,
   className,
   label,
   fullWidth,
+  selectedGenders,
+  selectedSizes,
+  handleSelectedCategoriesChange,
 }: IProps) => {
   const classes = makeStyles(theme as any)();
   const { t } = useTranslation();
 
-  const selectedGenders = genders;
-  const setSelectedSizes = setSizes;
-  const selectedSizes = sizes;
   const stylingClass = className;
 
-  //get selected categories
-  const handleChange = (event: any, setCategories: any) => {
+  const handleOnChange = (event: SelectChangeEvent<string[]>) => {
     const {
       target: { value },
     } = event;
 
-    setCategories(typeof value === "string" ? value.split(",") : value);
+    handleSelectedCategoriesChange(
+      typeof value === "string" ? value.split(",") : value
+    );
   };
 
   return (
@@ -69,7 +68,7 @@ const SizesDropdown: React.FC<IProps> = ({
         displayEmpty
         variant={variant}
         value={selectedSizes}
-        onChange={(e: any) => handleChange(e, setSelectedSizes)}
+        onChange={handleOnChange}
         renderValue={(selected: string[]) => {
           if (!selected.length) {
             return showInputLabel ? null : (

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -2,15 +2,15 @@ import * as React from "react";
 import { useTranslation } from "react-i18next";
 
 import {
-  MenuItem,
   FormControl,
+  InputLabel,
   Select,
   Input,
   OutlinedInput,
-  ListItemText,
+  MenuItem,
   Checkbox,
+  ListItemText,
   Typography,
-  InputLabel,
   SelectChangeEvent,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -88,7 +88,7 @@ const SizesDropdown: React.FC<IProps> = ({
         <Typography component="p" className={classes.label}>
           {t("childrenSizes")}
         </Typography>
-        {categories.children.map((value: any) => (
+        {categories.children.map((value: string) => (
           <MenuItem
             key={value}
             disabled={
@@ -116,7 +116,7 @@ const SizesDropdown: React.FC<IProps> = ({
         <Typography component="p" className={classes.label}>
           {t("womenSizes")}
         </Typography>
-        {categories.women.map((value: any) => (
+        {categories.women.map((value: string) => (
           <MenuItem
             disabled={
               !selectedGenders.includes("women") && !!selectedGenders.length
@@ -144,7 +144,7 @@ const SizesDropdown: React.FC<IProps> = ({
         <Typography component="p" className={classes.label}>
           {t("menSizes")}
         </Typography>
-        {categories.men.map((value: any) => (
+        {categories.men.map((value: string) => (
           <MenuItem
             disabled={
               !selectedGenders.includes("men") && !!selectedGenders.length

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -77,15 +77,18 @@ const SizesDropdown: React.FC<IProps> = ({
         value={selectedSizes}
         onChange={(e: any) => handleChange(e, setSelectedSizes)}
         renderValue={(selected: string[]) => {
-          if (selected.length === 0 && !inputVisible) {
-            return <em className={classes.em}>{label}</em>;
+          if (!selected.length) {
+            return inputVisible ? null : (
+              <Typography
+                component="span"
+                classes={{ root: classes.emptyRenderValue }}
+              >
+                {label}
+              </Typography>
+            );
+          } else {
+            return selected.map(t).join(", ");
           }
-
-          if (selected.length === 0 && inputVisible) {
-            return;
-          }
-
-          return selected.map(t).join(", ");
         }}
       >
         <Typography component="p" className={classes.label}>

--- a/frontend/src/components/SizesDropdown.tsx
+++ b/frontend/src/components/SizesDropdown.tsx
@@ -56,13 +56,7 @@ const SizesDropdown: React.FC<IProps> = ({
   return (
     <FormControl classes={{ root: classes.specificSpacing }} fullWidth>
       {inputVisible ? (
-        <InputLabel
-          id="demo-multiple-checkbox-label"
-          className={classes.labelSelect}
-          classes={{ root: classes.focusColor }}
-        >
-          {label}
-        </InputLabel>
+        <InputLabel classes={{ root: classes.labelSelect }}>{label}</InputLabel>
       ) : null}
       <Select
         className={stylingClass}

--- a/frontend/src/pages/AddChainAdmin.tsx
+++ b/frontend/src/pages/AddChainAdmin.tsx
@@ -35,15 +35,12 @@ export const AddChainAdmin = ({ location }: { location: any }) => {
       <Title>Select Co-Host</Title>
 
       <div className="add-chain-admin__select">
-        <FormControl className={classes.sizesFormWrapper}>
+        <FormControl classes={{ root: classes.specificSpacing }}>
           <Select
             className={classes.addChainAdminSelect}
             variant="outlined"
             value={selectedUser}
             onChange={handleSelectedUserChange}
-            inputProps={{
-              className: classes.specificSpacing,
-            }}
             renderValue={(selected: string) =>
               selected ? (
                 selected
@@ -65,7 +62,6 @@ export const AddChainAdmin = ({ location }: { location: any }) => {
               }) => (
                 <MenuItem
                   key={uid}
-                  className={classes.listItemTextSizes}
                   classes={{
                     root: classes.menuItemSpacingAndColor,
                     selected: classes.selected,

--- a/frontend/src/pages/AddChainAdmin.tsx
+++ b/frontend/src/pages/AddChainAdmin.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import {
-  Select,
   FormControl,
+  Select,
+  OutlinedInput,
   MenuItem,
-  Button,
   Typography,
+  Button,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
@@ -41,9 +42,19 @@ export const AddChainAdmin = ({ location }: { location: any }) => {
       <Title>Select Co-Host</Title>
 
       <div className="add-chain-admin__select">
-        <FormControl classes={{ root: classes.specificSpacing }}>
+        <FormControl classes={{ root: classes.specificSpacing }} fullWidth>
           <Select
-            className={classes.addChainAdminSelect}
+            displayEmpty
+            input={
+              <OutlinedInput
+                classes={{
+                  root: classes.selectInputOutlined,
+                }}
+              />
+            }
+            classes={{
+              select: classes.selectOutlined,
+            }}
             variant="outlined"
             value={selectedUser}
             onChange={handleSelectedUserChange}
@@ -57,7 +68,6 @@ export const AddChainAdmin = ({ location }: { location: any }) => {
                 </Typography>
               )
             }
-            displayEmpty
           >
             {users.map(
               ({

--- a/frontend/src/pages/AddChainAdmin.tsx
+++ b/frontend/src/pages/AddChainAdmin.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { Select, FormControl, MenuItem, Button } from "@mui/material";
+import {
+  Select,
+  FormControl,
+  MenuItem,
+  Button,
+  Typography,
+} from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
 import RightArrow from "../images/right-arrow-white.svg";
@@ -42,10 +48,13 @@ export const AddChainAdmin = ({ location }: { location: any }) => {
             value={selectedUser}
             onChange={handleSelectedUserChange}
             renderValue={(selected: string) =>
-              selected ? (
-                selected
-              ) : (
-                <em className={classes.em}>Select co-host</em>
+              selected ?? (
+                <Typography
+                  component="span"
+                  classes={{ root: classes.emptyRenderValue }}
+                >
+                  Select co-host
+                </Typography>
               )
             }
             displayEmpty

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -163,7 +163,6 @@ const Signup = () => {
                         showInputLabel={false}
                         className={classes.formSelect}
                         label={t("interestedSizes")}
-                        fullWidth={true}
                         selectedGenders={chainGender}
                         selectedSizes={selectedSizes}
                         handleSelectedCategoriesChange={setSelectedSizes}

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -160,13 +160,13 @@ const Signup = () => {
                     <div className={classes.formFieldWithPopover}>
                       <SizesDropdown
                         variant="standard"
+                        showInputLabel={false}
                         className={classes.formSelect}
                         setSizes={setSelectedSizes}
                         genders={chainGender}
                         sizes={selectedSizes}
                         label={t("interestedSizes")}
                         fullWidth={true}
-                        inputVisible={false}
                       />
                       <PopoverOnHover
                         message={

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -162,11 +162,11 @@ const Signup = () => {
                         variant="standard"
                         showInputLabel={false}
                         className={classes.formSelect}
-                        setSizes={setSelectedSizes}
-                        genders={chainGender}
-                        sizes={selectedSizes}
                         label={t("interestedSizes")}
                         fullWidth={true}
+                        selectedGenders={chainGender}
+                        selectedSizes={selectedSizes}
+                        handleSelectedCategoriesChange={setSelectedSizes}
                       />
                       <PopoverOnHover
                         message={

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -161,7 +161,6 @@ const Signup = () => {
                       <SizesDropdown
                         variant="standard"
                         showInputLabel={false}
-                        className={classes.formSelect}
                         label={t("interestedSizes")}
                         selectedGenders={chainGender}
                         selectedSizes={selectedSizes}

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -159,6 +159,7 @@ const Signup = () => {
 
                     <div className={classes.formFieldWithPopover}>
                       <SizesDropdown
+                        variant="standard"
                         className={classes.formSelect}
                         setSizes={setSelectedSizes}
                         genders={chainGender}
@@ -166,7 +167,6 @@ const Signup = () => {
                         label={t("interestedSizes")}
                         fullWidth={true}
                         inputVisible={false}
-                        variantVal={true}
                       />
                       <PopoverOnHover
                         message={

--- a/frontend/src/pages/UserEdit.js
+++ b/frontend/src/pages/UserEdit.js
@@ -157,13 +157,13 @@ const UserEdit = () => {
 
               <SizesDropdown
                 variant="standard"
+                showInputLabel={true}
                 className={classes.formSelect}
                 setSizes={setSelectedSizes}
                 genders={Object.keys(categories)}
                 sizes={selectedSizes}
                 label={t("interestedSizes")}
                 fullWidth={true}
-                inputVisible={true}
                 style={{ marginTop: "2%" }}
               />
 

--- a/frontend/src/pages/UserEdit.js
+++ b/frontend/src/pages/UserEdit.js
@@ -160,7 +160,6 @@ const UserEdit = () => {
                 showInputLabel={true}
                 className={classes.formSelect}
                 label={t("interestedSizes")}
-                fullWidth={true}
                 selectedGenders={Object.keys(categories)}
                 selectedSizes={selectedSizes}
                 handleSelectedCategoriesChange={setSelectedSizes}

--- a/frontend/src/pages/UserEdit.js
+++ b/frontend/src/pages/UserEdit.js
@@ -159,11 +159,11 @@ const UserEdit = () => {
                 variant="standard"
                 showInputLabel={true}
                 className={classes.formSelect}
-                setSizes={setSelectedSizes}
-                genders={Object.keys(categories)}
-                sizes={selectedSizes}
                 label={t("interestedSizes")}
                 fullWidth={true}
+                selectedGenders={Object.keys(categories)}
+                selectedSizes={selectedSizes}
+                handleSelectedCategoriesChange={setSelectedSizes}
                 style={{ marginTop: "2%" }}
               />
 

--- a/frontend/src/pages/UserEdit.js
+++ b/frontend/src/pages/UserEdit.js
@@ -158,7 +158,6 @@ const UserEdit = () => {
               <SizesDropdown
                 variant="standard"
                 showInputLabel={true}
-                className={classes.formSelect}
                 label={t("interestedSizes")}
                 selectedGenders={Object.keys(categories)}
                 selectedSizes={selectedSizes}

--- a/frontend/src/pages/UserEdit.js
+++ b/frontend/src/pages/UserEdit.js
@@ -156,6 +156,7 @@ const UserEdit = () => {
               />
 
               <SizesDropdown
+                variant="standard"
                 className={classes.formSelect}
                 setSizes={setSelectedSizes}
                 genders={Object.keys(categories)}
@@ -163,7 +164,6 @@ const UserEdit = () => {
                 label={t("interestedSizes")}
                 fullWidth={true}
                 inputVisible={true}
-                variantVal={true}
                 style={{ marginTop: "2%" }}
               />
 

--- a/frontend/src/util/theme.ts
+++ b/frontend/src/util/theme.ts
@@ -584,10 +584,6 @@ const theme = {
     borderBottom: "1px solid #dee3ed",
   },
 
-  checkbox: {
-    color: `${teal} !important`,
-  },
-
   actionsWrapper: {
     display: "flex",
   },

--- a/frontend/src/util/theme.ts
+++ b/frontend/src/util/theme.ts
@@ -715,12 +715,9 @@ const theme = {
     textTransform: "capitalize",
   },
 
-  listItemTextSizes: {
-    fontFamily: "Montserrat !important",
-  },
-
   listItemTextFontSize: {
     fontSize: "0.875rem",
+    textTransform: "capitalize",
   },
 
   menuItemSpacingAndColor: {

--- a/frontend/src/util/theme.ts
+++ b/frontend/src/util/theme.ts
@@ -935,11 +935,6 @@ const theme = {
     color: black,
   },
 
-  sizesFormWrapper: {
-    display: "flex !important",
-    flexDirection: "row !important",
-    position: "relative",
-  },
   popoverWrapper: {
     display: "flex",
     alignItems: "center",

--- a/frontend/src/util/theme.ts
+++ b/frontend/src/util/theme.ts
@@ -658,13 +658,11 @@ const theme = {
   },
 
   labelSelect: {
-    fontFamily: "Montserrat !important",
-    transform: "translate(0px, -6px) scale(0.75) !important",
-    color: "rgb(72, 128, 139, .4)",
     marginTop: "10px",
-
-    "& .MuiInputLabel-outlined.MuiInputLabel-shrink": {
-      transform: "translate(0px, -6px) scale(0.75) !important",
+    color: "rgb(72, 128, 139, .4)",
+    transform: "translate(0px, -6px) scale(0.75)",
+    "&:focus": {
+      color: "#f7c86f",
     },
   },
 
@@ -728,12 +726,6 @@ const theme = {
     },
   },
   selected: {},
-
-  focusColor: {
-    "&:focus": {
-      color: "#f7c86f",
-    },
-  },
 
   specificSpacing: {
     letterSpacing: "0.00938em",

--- a/frontend/src/util/theme.ts
+++ b/frontend/src/util/theme.ts
@@ -610,28 +610,16 @@ const theme = {
     padding: 10,
   },
 
-  select: {
+  selectInputOutlined: {
     color: black,
-    borderRadius: "0 !important",
-    backgroundColor: "transparent",
     width: "100%",
-    fontFamily: "Montserrat !important",
-    textTransform: "capitalize",
     border: `1px solid ${turquoise}`,
-
-    "& div#demo-multiple-checkbox": {
-      padding: "10px !important",
-    },
-
-    "&:before": {
-      borderColor: yellow,
-    },
-    "&:after": {
-      borderColor: yellow,
-    },
-    "&:not(.Mui-disabled):hover::before": {
-      borderColor: yellow,
-    },
+    borderRadius: "0",
+    backgroundColor: "transparent",
+    textTransform: "capitalize",
+  },
+  selectOutlined: {
+    padding: "10px",
   },
 
   addChainAdminSelect: {
@@ -672,19 +660,17 @@ const theme = {
     fontWeight: "500 !important",
   },
 
-  formSelect: {
-    margin: "5px auto 5px auto",
-    border: "none",
+  selectInputStandard: {
+    color: black,
     width: "100%",
-    borderRadius: "0 !important",
-    padding: "0 ",
-    marginTop: "16px",
+    margin: "5px auto 5px auto",
+    textTransform: "capitalize",
     "&:after": {
       borderColor: "#1976d2",
     },
   },
-  formControl: {
-    width: "15rem",
+  selectStandard: {
+    padding: "10px 10px 10px 0",
   },
 
   formWrapper: {
@@ -701,11 +687,6 @@ const theme = {
     fontStyle: "italic",
     fontWeight: "lighter",
     paddingLeft: "16px",
-  },
-
-  listItemText: {
-    fontFamily: "Montserrat !important",
-    textTransform: "capitalize",
   },
 
   listItemTextFontSize: {

--- a/frontend/src/util/theme.ts
+++ b/frontend/src/util/theme.ts
@@ -622,29 +622,6 @@ const theme = {
     padding: "10px",
   },
 
-  addChainAdminSelect: {
-    borderRadius: "0 !important",
-    backgroundColor: "transparent",
-    width: "100%",
-    fontFamily: "Montserrat !important",
-    textTransform: "capitalize",
-    border: `1px solid ${turquoise}`,
-
-    "& div#demo-multiple-checkbox": {
-      padding: "10px !important",
-    },
-
-    "&:before": {
-      borderColor: yellow,
-    },
-    "&:after": {
-      borderColor: yellow,
-    },
-    "&:not(.Mui-disabled):hover::before": {
-      borderColor: yellow,
-    },
-  },
-
   labelSelect: {
     marginTop: "10px",
     color: "rgb(72, 128, 139, .4)",

--- a/frontend/src/util/theme.ts
+++ b/frontend/src/util/theme.ts
@@ -622,6 +622,19 @@ const theme = {
     padding: "10px",
   },
 
+  selectInputStandard: {
+    color: black,
+    width: "100%",
+    margin: "5px auto 5px auto",
+    textTransform: "capitalize",
+    "&:after": {
+      borderColor: "#1976d2",
+    },
+  },
+  selectStandard: {
+    padding: "10px 10px 10px 0",
+  },
+
   labelSelect: {
     marginTop: "10px",
     color: "rgb(72, 128, 139, .4)",
@@ -635,19 +648,6 @@ const theme = {
     textTransform: "uppercase",
     color: black,
     fontWeight: "500 !important",
-  },
-
-  selectInputStandard: {
-    color: black,
-    width: "100%",
-    margin: "5px auto 5px auto",
-    textTransform: "capitalize",
-    "&:after": {
-      borderColor: "#1976d2",
-    },
-  },
-  selectStandard: {
-    padding: "10px 10px 10px 0",
   },
 
   formWrapper: {

--- a/frontend/src/util/theme.ts
+++ b/frontend/src/util/theme.ts
@@ -49,15 +49,10 @@ const theme = {
     lineHeight: "19.5px",
   },
 
-  em: {
+  emptyRenderValue: {
     color: "rgb(72, 128, 139, .4)",
-    fontStyle: "inherit",
-    float: "left",
-    fontWeight: "400",
-    fontSize: "1rem",
     lineHeight: "1.4375em",
     letterSpacing: " 0.00938em",
-    fontFamily: "Montserrat",
   },
 
   h3: {


### PR DESCRIPTION
Fix #219

- Standardized dropdown to `standard` and `outlined` variant
- Use `standard` variant for `SearchBar` (currently is a duplicated code)
- Cleaned the styling