### PR TITLE
Fix validation error for no loop location never appearing

### DIFF
--- a/frontend/src/components/ChainDetailsForm.tsx
+++ b/frontend/src/components/ChainDetailsForm.tsx
@@ -111,7 +111,7 @@ const ChainDetailsForm = ({ onSubmit, submitError, initialValues }: IProps) => {
       validationSchema={formSchema}
       validateOnChange={false}
       validate={(values: ChainFields) => {
-        if (values.longitude === null || values.latitude === null) {
+        if (values.longitude === 0 && values.latitude === 0) {
           return {
             longitude: "Please set the loop location by clicking the map",
           };


### PR DESCRIPTION
Fixes a form validation error not appearing when a user tries to create a loop without clicking the map to select a location. This was due to lat/long values being coerced to integers so never being null.