### PR TITLE
Add github action crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,24 @@
+name: Crowdin Action
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: crowdin action
+      uses: crowdin/github-action@1.4.9
+      with:
+        upload_translations: true
+        download_translations: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+        CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,6 @@
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+
 files:
   - source: /frontend/public/locales/en/*.json
     translation: /frontend/public/locales/%two_letters_code%/%original_file_name%


### PR DESCRIPTION
Runs a GitHub action that synchronizes main with Crowdin [documentation](https://crowdin.com/resources/marketplace/github-action)

Here is the action I tested it first on:
https://github.com/lil5/crowdin-i18n-example/runs/6762847849?check_suite_focus=true

And the automated PR it created:
https://github.com/lil5/crowdin-i18n-example/pull/2

In this project's [action secrets](https://github.com/CollActionteam/clothing-loop/settings/secrets/actions) you will find the following keys already added:
- `CROWDIN_PERSONAL_TOKEN`
- `CROWDIN_PROJECT_ID`

These keys allow successful connection with Crowdin (without requiring the owner of `CollActionTeam` to fiddle about with the GitHub integration)
